### PR TITLE
Prevent failing on fetching fields missing from ETF pages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.fross</groupId>
 	<artifactId>quoter</artifactId>
-	<version>5.0.19</version>
+	<version>5.0.20</version>
 	<packaging>jar</packaging>
 
 	<name>quoter</name>

--- a/src/main/java/org/fross/quoter/Symbol.java
+++ b/src/main/java/org/fross/quoter/Symbol.java
@@ -194,13 +194,11 @@ public class Symbol {
 
 				// Year to Date Change
 				key = "ytdChangePercent";
-				result = queryPageItem(htmlPage, xPathLookup.lookupSymbolClosed(key));
-				symbolData.put(key, result.replaceAll("[,%]", "").trim());
+				this.setOptionalField(htmlPage, key, MarketStatus.Closed);
 
 				// One Year Change Percent
 				key = "oneYearChangePercent";
-				result = queryPageItem(htmlPage, xPathLookup.lookupSymbolClosed(key));
-				symbolData.put(key, result.replaceAll("[,%]", "").trim());
+				this.setOptionalField(htmlPage, key, MarketStatus.Closed);
 
 				// TimeStamp
 				key = "timeStamp";
@@ -265,13 +263,11 @@ public class Symbol {
 
 				// Year to Date Change
 				key = "ytdChangePercent";
-				result = queryPageItem(htmlPage, xPathLookup.lookupSymbolOpen(key));
-				symbolData.put(key, result.replaceAll("[,%]", "").trim());
+				this.setOptionalField(htmlPage, key, MarketStatus.Open);
 
 				// One Year Change Percent
 				key = "oneYearChangePercent";
-				result = queryPageItem(htmlPage, xPathLookup.lookupSymbolOpen(key));
-				symbolData.put(key, result.replaceAll("[,%]", "").trim());
+				this.setOptionalField(htmlPage, key, MarketStatus.Open);
 
 				// TimeStamp
 				key = "timeStamp";
@@ -297,6 +293,25 @@ public class Symbol {
 			this.symbolData.put("status", "error");
 		}
 
+	}
+
+	private void setOptionalField(final Document htmlPage, final String key, final MarketStatus marketStatus) {
+		try {
+			final String result = queryPageItem(htmlPage,
+					marketStatus == MarketStatus.Closed ?
+							xPathLookup.lookupSymbolClosed(key) :
+							xPathLookup.lookupSymbolOpen(key)
+			);
+			symbolData.put(key, result.replaceAll("[,%]", "").trim());
+		} catch (Exception e) {
+			Output.debugPrintln("Failed to fetch key: " + key + " from page. Setting value as '---'");
+			symbolData.put(key, "---");
+		}
+	}
+
+	private enum MarketStatus {
+		Open,
+		Closed
 	}
 
 }

--- a/src/test/java/org/fross/quoter/SymbolTest.java
+++ b/src/test/java/org/fross/quoter/SymbolTest.java
@@ -37,8 +37,8 @@ class SymbolTest {
 	// Look through a list of symbols and ensure all the right fields are present
 	@Test
 	void testFields() {
-		String[] testSymbols = { "IBM", "TSLA", "GOOG" };
-		String[] symbolFullName = { "International Business Machines Corp.", "Tesla Inc.", "Alphabet Inc. Cl C" };
+		String[] testSymbols = { "IBM", "TSLA", "GOOG", "IVV" };
+		String[] symbolFullName = { "International Business Machines Corp.", "Tesla Inc.", "Alphabet Inc. Cl C", "iShares Core S&P 500 ETF" };
 		String[] testFields = { "symbol", "latestPrice", "change", "changePercent", "dayHigh", "dayLow", "ytdChangePercent", "oneYearChangePercent",
 				"timeStamp", "week52High", "week52Low", "fullname", "status" };
 


### PR DESCRIPTION
I noticed ETFs come back as an invalid symbol. There appears to be the YTD% and 1Year% not available on those fund pages (https://www.marketwatch.com/investing/fund/{symbol}) and the logic will not display the fields it was able to parse for the ETF.

This enhancement will ignore the optional fields if they don't exist and proceed with displaying the rest of the fields for the ETF.